### PR TITLE
feat: add support for closed issues and declined PR tracking

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS repos (
 CREATE TABLE IF NOT EXISTS events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   repo_id UUID REFERENCES repos(id) ON DELETE CASCADE,
-  type TEXT NOT NULL CHECK (type IN ('commit', 'release', 'pr_merge', 'repo_update')),
+  type TEXT NOT NULL CHECK (type IN ('commit', 'release', 'pr_merge', 'pr_closed', 'repo_update', 'issue', 'issue_closed')),
   title TEXT NOT NULL,
   summary TEXT NOT NULL,
   body TEXT,

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,4 @@
-export type EventType = 'commit' | 'release' | 'pr_merge' | 'repo_update' | 'issue'
+export type EventType = 'commit' | 'release' | 'pr_merge' | 'pr_closed' | 'repo_update' | 'issue' | 'issue_closed'
 export type EventStatus = 'pending' | 'approved' | 'rejected'
 
 export interface Repo {


### PR DESCRIPTION
## Description
Extends event tracking to capture issue closures and declined pull requests, providing complete visibility into repository activity lifecycle.

## Changes
- **Types**: Added `issue_closed` and `pr_closed` to `EventType`
- **Database Schema**: Updated CHECK constraint to allow new event types
- **GitHub Normalizer**: 
  - Added `normalizeIssueClosedEvent()` function
  - Added `normalizePRClosedEvent()` function
  - Handle `issues.closed` webhook action
  - Handle `pull_request.closed` (non-merged) webhook action

## Features Added
✅ Track when issues are closed/resolved  
✅ Track when PRs are declined (closed without merging)  
✅ Automatically tag events with appropriate labels ('closed', 'declined')

## Migration Required
Run this SQL in Supabase after merging:
```sql
ALTER TABLE events DROP CONSTRAINT IF EXISTS events_type_check;
ALTER TABLE events ADD CONSTRAINT events_type_check CHECK (type IN ('commit', 'release', 'pr_merge', 'pr_closed', 'repo_update', 'issue', 'issue_closed'));