### PR TITLE
Add PR, Issue & Release Information to Event Details at event page footer

### DIFF
--- a/app/api/events/[id]/details/route.ts
+++ b/app/api/events/[id]/details/route.ts
@@ -24,10 +24,12 @@ export async function GET(
       return NextResponse.json({ error: 'Event not found' }, { status: 404 })
     }
 
-    // Extract GitHub info from source_url
+    // Extract GitHub info from source_url for any event type
     let commitDetails = null
 
-    if (event.type === 'commit' && event.source_url) {
+    // Fetch commit details for any event with a GitHub source URL
+    // This includes: commits, PRs (merge/closed), releases, and issues
+    if (event.source_url && event.source_url.includes('github.com')) {
       const githubToken = process.env.GITHUB_TOKEN
 
       // Try to fetch commit details from GitHub API
@@ -36,18 +38,20 @@ export async function GET(
           // Parse owner/repo from source_url
           // Example: https://github.com/owner/repo/compare/abc...def
           // or https://github.com/owner/repo/commit/sha
+          // or https://github.com/owner/repo/pull/123
           const urlMatch = event.source_url.match(/github\.com\/([^\/]+)\/([^\/]+)/)
-          
+
           if (urlMatch) {
             const [, owner, repo] = urlMatch
-            
-            // Check if it's a compare URL (multiple commits) or single commit
+
+            // Handle different URL patterns
+            // 1. Compare URLs (multiple commits)
             if (event.source_url.includes('/compare/')) {
               // For compare URLs, extract commit range
               const compareMatch = event.source_url.match(/compare\/([^\.]+)\.\.\.([^\/\?#]+)/)
               if (compareMatch) {
                 const [, base, head] = compareMatch
-                
+
                 // Fetch compare data
                 const compareUrl = `https://api.github.com/repos/${owner}/${repo}/compare/${base}...${head}`
                 const compareResponse = await fetch(compareUrl, {
@@ -83,12 +87,131 @@ export async function GET(
                   }
                 }
               }
-            } else if (event.source_url.includes('/commit/')) {
-              // Single commit URL
+            }
+            // 2. Pull request URLs
+            else if (event.source_url.includes('/pull/')) {
+              const prMatch = event.source_url.match(/pull\/(\d+)/)
+              if (prMatch) {
+                const prNumber = prMatch[1]
+
+                // Fetch PR commits
+                const prUrl = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/commits`
+                const prResponse = await fetch(prUrl, {
+                  headers: {
+                    Authorization: `Bearer ${githubToken}`,
+                    Accept: 'application/vnd.github.v3+json',
+                  },
+                })
+
+                if (prResponse.ok) {
+                  const commits = await prResponse.json()
+
+                  // Also fetch PR files
+                  const filesUrl = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`
+                  const filesResponse = await fetch(filesUrl, {
+                    headers: {
+                      Authorization: `Bearer ${githubToken}`,
+                      Accept: 'application/vnd.github.v3+json',
+                    },
+                  })
+
+                  let files = []
+                  let additions = 0
+                  let deletions = 0
+
+                  if (filesResponse.ok) {
+                    files = await filesResponse.json()
+                    additions = files.reduce((sum: number, f: any) => sum + (f.additions || 0), 0)
+                    deletions = files.reduce((sum: number, f: any) => sum + (f.deletions || 0), 0)
+                  }
+
+                  commitDetails = {
+                    commits: commits.map((c: any) => ({
+                      sha: c.sha,
+                      message: c.commit.message,
+                      author: c.commit.author,
+                      url: c.html_url,
+                    })),
+                    files: files.map((f: any) => ({
+                      filename: f.filename,
+                      status: f.status,
+                      additions: f.additions || 0,
+                      deletions: f.deletions || 0,
+                      changes: f.changes || 0,
+                      patch: f.patch,
+                    })),
+                    stats: {
+                      total_commits: commits.length,
+                      files_changed: files.length,
+                      additions,
+                      deletions,
+                    },
+                  }
+                }
+              }
+            }
+            // 3. Release URLs
+            else if (event.source_url.includes('/releases/tag/') || event.source_url.includes('/releases/')) {
+              const releaseMatch = event.source_url.match(/releases\/tag\/([^\/\?#]+)/)
+              if (releaseMatch) {
+                const tagName = releaseMatch[1]
+
+                // Fetch tag information to get the commit SHA
+                const tagUrl = `https://api.github.com/repos/${owner}/${repo}/git/refs/tags/${tagName}`
+                const tagResponse = await fetch(tagUrl, {
+                  headers: {
+                    Authorization: `Bearer ${githubToken}`,
+                    Accept: 'application/vnd.github.v3+json',
+                  },
+                })
+
+                if (tagResponse.ok) {
+                  const tagData = await tagResponse.json()
+                  const commitSha = tagData.object.sha
+
+                  // Fetch the commit details
+                  const commitUrl = `https://api.github.com/repos/${owner}/${repo}/commits/${commitSha}`
+                  const commitResponse = await fetch(commitUrl, {
+                    headers: {
+                      Authorization: `Bearer ${githubToken}`,
+                      Accept: 'application/vnd.github.v3+json',
+                    },
+                  })
+
+                  if (commitResponse.ok) {
+                    const commitData = await commitResponse.json()
+                    commitDetails = {
+                      commits: [{
+                        sha: commitData.sha,
+                        message: commitData.commit.message,
+                        author: commitData.commit.author,
+                        url: commitData.html_url,
+                      }],
+                      files: commitData.files?.map((f: any) => ({
+                        filename: f.filename,
+                        status: f.status,
+                        additions: f.additions,
+                        deletions: f.deletions,
+                        changes: f.changes,
+                        patch: f.patch,
+                      })) || [],
+                      stats: {
+                        total_commits: 1,
+                        files_changed: commitData.files?.length || 0,
+                        additions: commitData.stats?.additions || 0,
+                        deletions: commitData.stats?.deletions || 0,
+                      },
+                    }
+                  }
+                }
+              }
+            }
+            // 4. Single commit URLs
+            else if (event.source_url.includes('/commit/')) {
               const commitMatch = event.source_url.match(/commit\/([a-f0-9]+)/)
               if (commitMatch) {
                 const sha = commitMatch[1]
-                
+
                 const commitUrl = `https://api.github.com/repos/${owner}/${repo}/commits/${sha}`
                 const commitResponse = await fetch(commitUrl, {
                   headers: {

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -164,8 +164,8 @@ export default function EventDetailPage() {
           )}
         </div>
 
-        {/* Commit Details */}
-        {details && (
+        {/* Commit Details - Only show for commit types (not releases, PRs, or issues) */}
+        {details && !['release', 'pr_merge', 'pr_closed', 'issue', 'issue_closed'].includes(event.type) && (
           <>
             {/* Stats */}
             <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 mb-6">
@@ -207,18 +207,28 @@ export default function EventDetailPage() {
             </div>
 
             {/* Commits List */}
-            {details.commits.length > 1 && (
+            {details.commits.length > 0 && (
               <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 mb-6">
-                <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Commits</h2>
-                <div className="space-y-3">
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+                  Commits {details.commits.length > 1 && `(${details.commits.length})`}
+                </h2>
+                <div className="space-y-4">
                   {details.commits.map((commit) => (
-                    <div key={commit.sha} className="border-l-2 border-blue-500 pl-4">
-                      <div className="font-mono text-sm text-gray-600 dark:text-gray-400 mb-1">
-                        {commit.sha.substring(0, 7)}
+                    <div key={commit.sha} className="border-l-4 border-blue-500 dark:border-blue-400 pl-4 py-2">
+                      <div className="flex items-center gap-2 mb-2">
+                        <a
+                          href={commit.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="font-mono text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                          title="View commit on GitHub"
+                        >
+                          {commit.sha.substring(0, 7)}
+                        </a>
                       </div>
                       <MarkdownRenderer
                         content={commit.message.split('\n')[0]}
-                        className="text-gray-900 dark:text-white font-medium prose prose-sm dark:prose-invert max-w-none [&>*]:inline [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+                        className="text-gray-900 dark:text-white font-medium prose prose-sm dark:prose-invert max-w-none [&>*]:inline [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 mb-2"
                       />
                       <div className="text-sm text-gray-600 dark:text-gray-400">
                         {commit.author.name} • {new Date(commit.author.date).toLocaleString()}
@@ -248,6 +258,102 @@ export default function EventDetailPage() {
               </div>
             </div>
           </>
+        )}
+
+        {/* Pull Request Information - Only for PR events */}
+        {(event.type === 'pr_merge' || event.type === 'pr_closed') && (
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 mb-6">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Pull Request Information</h2>
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 w-32">PR Number:</span>
+                <a
+                  href={event.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-lg text-blue-600 dark:text-blue-400 hover:underline font-semibold"
+                >
+                  #{event.source_url.match(/pull\/(\d+)/)?.[1] || 'View PR'}
+                </a>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 w-32">Status:</span>
+                <span className={`px-3 py-1 text-sm rounded-full ${event.type === 'pr_merge'
+                    ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200'
+                  }`}>
+                  {event.type === 'pr_merge' ? 'Merged' : 'Closed'}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 w-32">Date:</span>
+                <span className="text-sm text-gray-900 dark:text-white">
+                  {new Date(event.timestamp).toLocaleString()}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Issue Information - Only for issue events */}
+        {(event.type === 'issue' || event.type === 'issue_closed') && (
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 mb-6">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Issue Information</h2>
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 w-32">Issue Number:</span>
+                <a
+                  href={event.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-lg text-blue-600 dark:text-blue-400 hover:underline font-semibold"
+                >
+                  #{event.source_url.match(/issues\/(\d+)/)?.[1] || 'View Issue'}
+                </a>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 w-32">Status:</span>
+                <span className={`px-3 py-1 text-sm rounded-full ${event.type === 'issue_closed'
+                    ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200'
+                    : 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200'
+                  }`}>
+                  {event.type === 'issue_closed' ? 'Closed' : 'Open'}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 w-32">Date:</span>
+                <span className="text-sm text-gray-900 dark:text-white">
+                  {new Date(event.timestamp).toLocaleString()}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Release Information - Only for release events */}
+        {event.type === 'release' && (
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 mb-6">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Release Information</h2>
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 w-32">Release Tag:</span>
+                <a
+                  href={event.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-lg text-blue-600 dark:text-blue-400 hover:underline font-semibold"
+                >
+                  {event.source_url.split('/').pop() || 'View Release'}
+                </a>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 w-32">Date:</span>
+                <span className="text-sm text-gray-900 dark:text-white">
+                  {new Date(event.timestamp).toLocaleString()}
+                </span>
+              </div>
+            </div>
+          </div>
         )}
 
         {/* View on GitHub */}


### PR DESCRIPTION
## ✨ Add PR, Issue & Release Information to Event Details

### Overview

This PR enhances the **event detail view and backend API** to properly handle **Pull Requests, Issues, and Releases**, instead of treating everything as a simple commit event.

It ensures the UI shows **relevant information per event type** and the API fetches **accurate GitHub data** based on the event’s `source_url`.

---

## 🚀 What’s Changed

### 1. Backend: Smarter GitHub URL Handling

**File:** `app/api/events/[id]/details/route.ts`

The API now detects and handles multiple GitHub URL patterns:

* **Compare URLs**

  * Fetches all commits in the range
  * Aggregates files, additions, and deletions

* **Pull Requests (`/pull/:id`)**

  * Fetches:

    * All PR commits
    * Changed files
    * Additions & deletions
  * Normalizes data into a unified `commitDetails` structure

* **Releases (`/releases/tag/:tag`)**

  * Resolves tag → commit SHA
  * Fetches commit details and file stats for the release

* **Single Commits (`/commit/:sha`)**

  * Fetches full commit metadata and file diffs

This makes the API **event-type agnostic** and future-proof for new GitHub event formats.

---

### 2. Frontend: Event-Type Aware Rendering

**File:** `app/events/[id]/page.tsx`

The event detail page now conditionally renders sections based on `event.type`:

#### ✅ Commit Events

* Commit stats (files changed, additions, deletions)
* Commit list with:

  * SHA links to GitHub
  * Proper spacing & hierarchy
  * Markdown-rendered commit messages

#### ✅ Pull Request Events

* Dedicated **Pull Request Information** section:

  * PR number (linked to GitHub)
  * Status: **Merged** or **Closed**
  * Event timestamp
* Commit details are **intentionally hidden** for PR events to avoid confusion

#### ✅ Issue Events

* Dedicated **Issue Information** section:

  * Issue number (linked to GitHub)
  * Status: **Open** or **Closed**
  * Event timestamp

#### ✅ Release Events

* Dedicated **Release Information** section:

  * Release tag
  * Release date
  * Direct link to GitHub release

---

### 3. UI & UX Improvements

* Commit SHAs are clickable and open in GitHub
* Clear visual separation between:

  * Commits
  * PRs
  * Issues
  * Releases
* Prevents irrelevant sections from appearing for the wrong event type
* Improves readability and reduces cognitive overload

---

## 🧪 Safety & Edge Cases

* Gracefully handles missing or unexpected GitHub data
* Avoids showing commit stats for PRs, issues, and releases
* All external links use `target="_blank"` with `rel="noopener noreferrer"`

---

## 📈 Impact

* Accurate representation of GitHub activity
* Clear, context-aware event detail pages
* Strong foundation for future enhancements like:

  * PR descriptions
  * Issue bodies
  * Release notes rendering

---
